### PR TITLE
docs: fix new lines

### DIFF
--- a/elderguide.com/elderjs.md
+++ b/elderguide.com/elderjs.md
@@ -286,6 +286,7 @@ That said, if you are hitting a DB and want to manage your connection in a reusa
 Using this pattern allows you to share a database connection across the entire lifecycle of your Elder.js site.
 
 **Cache Data Where Possible Within Route.js Files**
+
 If you have a data heavy calculation required to generate a page, look into calculating that data and caching it before your `module.exports` definition like so:
 
 ```javascript
@@ -319,6 +320,7 @@ module.exports = {
 ```
 
 **Data Used in Multiple Routes**
+
 If you have data that is used in multiple routes, you can share that data between routes by populating the `data` object on the `boostrap` hook documented later in this guide.
 
 Assuming you have populated the `data.cities` with an array of cities on the `boostrap` hook you could access it like so:


### PR DESCRIPTION
Hi 🦖 

I found not spaced words in [elderguide.com/tech/elderjs/](https://elderguide.com/tech/elderjs/) like below image.

<img width="1271" alt="スクリーンショット 2020-10-05 19 22 23" src="https://user-images.githubusercontent.com/39523918/95068346-25e50700-0740-11eb-8635-3e8b8024e4ab.png">

It is caused by [not existing newline](https://raw.githubusercontent.com/Elderjs/docs/master/elderguide.com/elderjs.md#:~:text=Files**,If) after heading, so heading and text are in same `<p>` tag element in converting markdown file to html string.

I've not tried that because no way to confirm it, and I hope this PR would work to fix it.